### PR TITLE
Add CI/CD pipeline with GHCR and VPS deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,62 @@
+name: Deploy
+
+on:
+  workflow_run:
+    workflows: ["Test express-api"]
+    types: [completed]
+    branches: [master]
+
+jobs:
+  build-and-push:
+    if: github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/aiiion/express-api:latest
+            ghcr.io/aiiion/express-api:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Deploy to VPS
+        uses: appleboy/ssh-action@v1
+        env:
+          GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
+          DEPLOY_PATH: ${{ secrets.VPS_DEPLOY_PATH }}
+        with:
+          host: ${{ secrets.VPS_HOST }}
+          username: ${{ secrets.VPS_USER }}
+          key: ${{ secrets.VPS_SSH_KEY }}
+          envs: GHCR_TOKEN,ACTOR,DEPLOY_PATH
+          script: |
+            echo "$GHCR_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
+            cd "$DEPLOY_PATH"
+            docker compose pull api
+            docker compose up -d --remove-orphans
+            docker image prune -f

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,7 @@ jobs:
           key: ${{ secrets.VPS_SSH_KEY }}
           envs: GHCR_TOKEN,ACTOR,DEPLOY_PATH
           script: |
+            set -e
             echo "$GHCR_TOKEN" | docker login ghcr.io -u "$ACTOR" --password-stdin
             cd "$DEPLOY_PATH"
             docker compose pull api

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,22 +15,23 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
+          persist-credentials: false
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         with:
           context: .
           push: true
@@ -46,7 +47,7 @@ jobs:
 
     steps:
       - name: Deploy to VPS
-        uses: appleboy/ssh-action@v1
+        uses: appleboy/ssh-action@0ff4204d59e8e51228ff73bce53f80d53301dee2 # v1
         env:
           GHCR_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ACTOR: ${{ github.actor }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,7 +34,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/aiiion/express-api:latest
-            ghcr.io/aiiion/express-api:${{ github.sha }}
+            ghcr.io/aiiion/express-api:${{ github.event.workflow_run.head_sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Commands
+
+**Development:**
+```bash
+# Full containerized dev (DB + API with hot-reload)
+npm run docker:dev
+
+# Run only DB and Redis in Docker, app natively (requires DB_HOST=localhost and REDIS_URL=redis://localhost:6379 in .env)
+docker compose -f docker-compose.dev.yml up db redis -d && npm run start:dev
+```
+
+**Tests** — Postgres and Redis must be reachable; run migrations and seeders first:
+```bash
+npm run migrate && npm run db:seed
+npm test                                                          # full suite
+npm test -- --runTestsByPath src/tests/cache.middleware.test.mjs  # single file
+npm test -- --runTestsByPath src/tests/cache.middleware.test.mjs -t "returns a cached response when Redis has a value"  # single test
+```
+
+**Database:**
+```bash
+npm run migrate          # run pending migrations
+npm run migrate:down     # rollback last migration
+npm run db:seed          # run seeders
+npm run db:seed:undo     # undo seeders
+```
+
+There are no lint or build scripts.
+
+## Architecture
+
+**Entrypoint:** `src/index.mjs` builds the Express app, applies middleware (helmet, JSON, cookie-parser, request logger, global error handler), mounts routes, then `start()` connects Postgres + Redis, initializes Sequelize models, and registers cron jobs. The server does not auto-start when `NODE_ENV=test` — most test files call `start(0)` themselves.
+
+**Routing** is composed in `src/routes/index.route.mjs`. Route modules (not controllers) own request-level concerns: they compose `checkSchema(...)`, `validateResult`, CORS, and auth middleware before handing off to a controller. Validation schemas are shared from `src/utils/validationSchemas.mjs`.
+
+**CORS** is per-route, not global. `src/utils/corsHelpers.mjs` reads `CORS_ALLOWLIST` (comma-separated). Requests without an `Origin` pass as non-CORS; disallowed origins get a 403-style error.
+
+**Weather endpoint** (`GET /v1/weather`) is a multi-provider aggregation pipeline:
+- Four provider clients (`src/services/*.service.mjs`) fetch data in parallel
+- Each normalizes its response via `src/dtos/*.dto.mjs` into a shared shape
+- `src/services/weatherAggregator.service.mjs` merges results: averages overlapping numeric fields, has custom precipitation-window merging, and returns partial data when some providers fail
+
+**Authentication** is a two-step email flow backed by Redis:
+1. `POST /v1/auth/login` — validates admin password, stores a 6-digit code + session token in Redis (10-minute TTL), emails the code via Resend
+2. `POST /v1/auth/verify` — validates session token + code, deletes the one-time Redis session, sets a signed JWT in an HTTP-only cookie (`jwt_token`, 3h TTL)
+- Login is rate-limited (10 req / 15 min) using `express-rate-limit` with a Redis store; in-memory store when `NODE_ENV=test`
+- Protected endpoints use an `authenticate` middleware that reads the JWT cookie
+
+**Request logging** is asynchronous and two-stage:
+- `src/middleware/log.middleware.mjs` queues structured log payloads into Redis after each response
+- `src/jobs/flush-request-logs.mjs` flushes the queue to Postgres in batches with a Redis lock (avoids concurrent flushers); uses `bulkCreate(..., { ignoreDuplicates: true })` with `stable_id` for deduplication
+- `src/jobs/purge-old-logs.mjs` removes old rows from both `request_logs` and `error_logs`
+- `src/cron.mjs` schedules flushing every 2 minutes and purging daily at 05:00 UTC
+
+**Database** uses both `pg` and Sequelize. `src/services/db.service.mjs` owns the low-level `pg` connectivity check. `src/models/index.mjs` creates the Sequelize instance. Schema is managed entirely through migrations in `src/db/migrations/` — `sequelize.sync()` is never used.
+
+**Response shape conventions:**
+- Errors: `{ code, message }`
+- Single resource: `{ data: ... }`
+- Lists: `{ data: [...], pagination: { page, perPage, totalPages, totalCount } }`
+
+## Key conventions
+
+- All source files use ESM `.mjs`. Tests that mock modules use `jest.unstable_mockModule(...)` and only import the module under test *after* the mock is set up.
+- Fixtures (`src/fixtures/`) and DTOs (`src/dtos/`) pair one-to-one per weather provider.
+- `src/data/borders/` contains geographic boundary data used by geo helpers for weather warning region checks.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   api:
     build: .
+    image: ghcr.io/aiiion/express-api:latest
     container_name: express-api
     ports:
       - "3000:3000"


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with project context for Claude Code
- Adds `.github/workflows/deploy.yml` — triggers after tests pass on master, builds and pushes the Docker image to GHCR, then SSHes to the VPS to pull and restart the API container
- Adds `image: ghcr.io/aiiion/express-api:latest` to `docker-compose.yml` so Compose knows where to pull from on the VPS

## Deploy flow
`push to master` → tests pass → build & push image to GHCR → SSH to VPS → `docker compose pull api && docker compose up -d`

## First-time VPS step after merging
```bash
cd /your/deploy/path && git pull
```
Required once to get the updated `docker-compose.yml` onto the VPS before the pipeline takes over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated deployment workflow that builds and deploys the application to production upon successful test completion.
  * Updated container deployment configuration to use pre-built Docker images.
  * Added internal development and architecture documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->