### PR TITLE
Performance and code structure improvements

### DIFF
--- a/src/controllers/v1/errorLogs.controller.mjs
+++ b/src/controllers/v1/errorLogs.controller.mjs
@@ -1,48 +1,40 @@
 import { Op } from 'sequelize';
 import { sequelize } from '../../models/index.mjs';
-import { devError } from '../../utils/logger.mjs';
 
 const LOGS_PER_PAGE = 100;
 
 export const index = async (req, res) => {
-  try {
-    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
-    const offset = (page - 1) * LOGS_PER_PAGE;
+  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+  const offset = (page - 1) * LOGS_PER_PAGE;
 
-    const where = {};
+  const where = {};
 
-    if (req.query.search) {
-      const pattern = `%${req.query.search}%`;
-      where[Op.or] = [
-        { message: { [Op.iLike]: pattern } },
-        { route: { [Op.iLike]: pattern } },
-        { stack_trace: { [Op.iLike]: pattern } }
-      ];
-    }
-
-    const ErrorLog = sequelize.models.ErrorLog;
-    const { count, rows } = await ErrorLog.findAndCountAll({
-      where,
-      limit: LOGS_PER_PAGE,
-      offset,
-      order: [['created_at', 'DESC']]
-    });
-
-    const totalPages = Math.ceil(count / LOGS_PER_PAGE);
-
-    return res.status(200).json({
-      data: rows,
-      pagination: {
-        page,
-        perPage: LOGS_PER_PAGE,
-        totalPages,
-        totalCount: count
-      }
-    });
-  } catch (error) {
-    devError('error logs index error:', error.message);
-    return res.status(500).json({
-      error: 'Failed to retrieve error logs'
-    });
+  if (req.query.search) {
+    const pattern = `%${req.query.search}%`;
+    where[Op.or] = [
+      { message: { [Op.iLike]: pattern } },
+      { route: { [Op.iLike]: pattern } },
+      { stack_trace: { [Op.iLike]: pattern } }
+    ];
   }
+
+  const ErrorLog = sequelize.models.ErrorLog;
+  const { count, rows } = await ErrorLog.findAndCountAll({
+    where,
+    limit: LOGS_PER_PAGE,
+    offset,
+    order: [['created_at', 'DESC']]
+  });
+
+  const totalPages = Math.ceil(count / LOGS_PER_PAGE);
+
+  return res.status(200).json({
+    data: rows,
+    pagination: {
+      page,
+      perPage: LOGS_PER_PAGE,
+      totalPages,
+      totalCount: count
+    }
+  });
 };

--- a/src/controllers/v1/requestLogs.controller.mjs
+++ b/src/controllers/v1/requestLogs.controller.mjs
@@ -1,60 +1,52 @@
 import { Op } from 'sequelize';
 import { sequelize } from '../../models/index.mjs';
-import { devError } from '../../utils/logger.mjs';
 
 const LOGS_PER_PAGE = 100;
 
 export const index = async (req, res) => {
-  try {
-    const page = Math.max(1, parseInt(req.query.page, 10) || 1);
-    const offset = (page - 1) * LOGS_PER_PAGE;
+  const page = Math.max(1, parseInt(req.query.page, 10) || 1);
+  const offset = (page - 1) * LOGS_PER_PAGE;
 
-    const where = {};
+  const where = {};
 
-    if (req.query.code !== undefined) {
-      const codes = Array.isArray(req.query.code)
-        ? req.query.code.map(c => parseInt(c, 10)).filter(c => !isNaN(c))
-        : [parseInt(req.query.code, 10)].filter(c => !isNaN(c));
+  if (req.query.code !== undefined) {
+    const codes = Array.isArray(req.query.code)
+      ? req.query.code.map(c => parseInt(c, 10)).filter(c => !isNaN(c))
+      : [parseInt(req.query.code, 10)].filter(c => !isNaN(c));
 
-      if (codes.length === 1) {
-        where.code = codes[0];
-      } else if (codes.length > 1) {
-        where.code = { [Op.in]: codes };
-      }
+    if (codes.length === 1) {
+      where.code = codes[0];
+    } else if (codes.length > 1) {
+      where.code = { [Op.in]: codes };
     }
-
-    if (req.query.search) {
-      const pattern = `%${req.query.search}%`;
-      where[Op.or] = [
-        { route: { [Op.iLike]: pattern } },
-        { ip: { [Op.iLike]: pattern } },
-        { description: { [Op.iLike]: pattern } }
-      ];
-    }
-
-    const RequestLog = sequelize.models.RequestLog;
-    const { count, rows } = await RequestLog.findAndCountAll({
-      where,
-      limit: LOGS_PER_PAGE,
-      offset,
-      order: [['created_at', 'DESC']]
-    });
-
-    const totalPages = Math.ceil(count / LOGS_PER_PAGE);
-
-    return res.status(200).json({
-      data: rows,
-      pagination: {
-        page,
-        perPage: LOGS_PER_PAGE,
-        totalPages,
-        totalCount: count
-      }
-    });
-  } catch (error) {
-    devError('request logs index error:', error.message);
-    return res.status(500).json({
-      error: 'Failed to retrieve request logs'
-    });
   }
+
+  if (req.query.search) {
+    const pattern = `%${req.query.search}%`;
+    where[Op.or] = [
+      { route: { [Op.iLike]: pattern } },
+      { ip: { [Op.iLike]: pattern } },
+      { description: { [Op.iLike]: pattern } }
+    ];
+  }
+
+  const RequestLog = sequelize.models.RequestLog;
+  const { count, rows } = await RequestLog.findAndCountAll({
+    where,
+    limit: LOGS_PER_PAGE,
+    offset,
+    order: [['created_at', 'DESC']]
+  });
+
+  const totalPages = Math.ceil(count / LOGS_PER_PAGE);
+
+  return res.status(200).json({
+    data: rows,
+    pagination: {
+      page,
+      perPage: LOGS_PER_PAGE,
+      totalPages,
+      totalCount: count
+    }
+  });
 };

--- a/src/services/redis.service.mjs
+++ b/src/services/redis.service.mjs
@@ -85,17 +85,13 @@ export const getRequestLogProcessingLength = async () => {
 
 export const moveRequestLogsToProcessing = async (count) => {
   if (!count || count < 1) return 0;
-
   const client = await getClient();
-  let moved = 0;
-
-  while (moved < count) {
-    const entry = await client.sendCommand(['RPOPLPUSH', REQUEST_LOGS_QUEUE_KEY, REQUEST_LOGS_PROCESSING_KEY]);
-    if (!entry) break;
-    moved += 1;
+  const tx = client.multi();
+  for (let i = 0; i < count; i++) {
+    tx.lMove(REQUEST_LOGS_QUEUE_KEY, REQUEST_LOGS_PROCESSING_KEY, 'RIGHT', 'LEFT');
   }
-
-  return moved;
+  const results = await tx.exec();
+  return results.filter(r => r !== null).length;
 };
 
 export const getProcessingRequestLogs = async () => {

--- a/src/services/weatherAggregator.service.mjs
+++ b/src/services/weatherAggregator.service.mjs
@@ -418,11 +418,16 @@ const mergeForecastData = (sources) => {
 
 const collectProvider = (result, dtoFn, name, route) => {
   if (result.status === 'fulfilled') {
-    const normalized = dtoFn(result.value);
-    if (normalized) return { source: normalized, provider: normalized.provider ?? name };
+    try {
+      const normalized = dtoFn(result.value);
+      if (normalized) return { source: normalized, provider: normalized.provider ?? name };
+    } catch (err) {
+      logError(err, { route });
+      return { error: { provider: name, message: err?.message ?? String(err) } };
+    }
   } else {
     logError(result.reason, { route });
-    return { error: { provider: name, message: result.reason?.message ?? String(result.reason) ?? 'Unknown error' } };
+    return { error: { provider: name, message: result.reason?.message ?? String(result.reason) } };
   }
   return {};
 };

--- a/src/services/weatherAggregator.service.mjs
+++ b/src/services/weatherAggregator.service.mjs
@@ -416,6 +416,17 @@ const mergeForecastData = (sources) => {
   };
 };
 
+const collectProvider = (result, dtoFn, name, route) => {
+  if (result.status === 'fulfilled') {
+    const normalized = dtoFn(result.value);
+    if (normalized) return { source: normalized, provider: normalized.provider ?? name };
+  } else {
+    logError(result.reason, { route });
+    return { error: { provider: name, message: result.reason?.message ?? String(result.reason) ?? 'Unknown error' } };
+  }
+  return {};
+};
+
 /**
  * Processes settled current weather results from all providers into a merged response.
  * @param {PromiseSettledResult} owmResult
@@ -426,69 +437,20 @@ const mergeForecastData = (sources) => {
  * @returns {Object}
  */
 const processCurrentWeather = (owmResult, weatherApiResult, smhiResult, metResult, metric = true) => {
-  const sources = [];
-  const errors = [];
-  const providers = [];
-
-  if (owmResult.status === "fulfilled") {
-    const normalizedOwm = openWeatherMapsDto.currentWeather(owmResult.value);
-    if (normalizedOwm) {
-      sources.push(normalizedOwm);
-      providers.push(normalizedOwm.provider || "openweathermaps.org");
-    }
-  } else {
-    const owmMsg = owmResult?.reason?.message ?? String(owmResult?.reason) ?? "Unknown error";
-    errors.push({ provider: "openweathermaps.org", message: owmMsg });
-    logError(owmResult.reason, { route: "weatherAggregator.currentWeather" });
-  }
-
-  if (weatherApiResult.status === "fulfilled") {
-    const normalizedWeatherApi = weatherApiDto.currentWeather(weatherApiResult.value, metric);
-    if (normalizedWeatherApi) {
-      sources.push(normalizedWeatherApi);
-      providers.push(normalizedWeatherApi.provider || "weatherapi.com");
-    }
-  } else {
-    const waMsg = weatherApiResult?.reason?.message ?? String(weatherApiResult?.reason) ?? "Unknown error";
-    errors.push({ provider: "weatherapi.com", message: waMsg });
-    logError(weatherApiResult.reason, { route: "weatherAggregator.currentWeather" });
-  }
-
-  if (smhiResult.status === "fulfilled") {
-    const normalizedSmhi = smhiDto.currentWeather(smhiResult.value, metric);
-    if (normalizedSmhi) {
-      sources.push(normalizedSmhi);
-      providers.push(normalizedSmhi.provider || "smhi.se");
-    }
-  } else {
-    const smhiMsg = smhiResult?.reason?.message ?? String(smhiResult?.reason) ?? "Unknown error";
-    errors.push({ provider: "smhi.se", message: smhiMsg });
-    logError(smhiResult.reason, { route: "weatherAggregator.currentWeather" });
-  }
-
-  if (metResult.status === "fulfilled") {
-    const normalizedMet = metDto.currentWeather(metResult.value, metric);
-    if (normalizedMet) {
-      sources.push(normalizedMet);
-      providers.push(normalizedMet.provider || "met.no");
-    }
-  } else {
-    const metMsg = metResult?.reason?.message ?? String(metResult?.reason) ?? "Unknown error";
-    errors.push({ provider: "met.no", message: metMsg });
-    logError(metResult.reason, { route: "weatherAggregator.currentWeather" });
-  }
+  const route = 'weatherAggregator.currentWeather';
+  const collected = [
+    collectProvider(owmResult, v => openWeatherMapsDto.currentWeather(v), 'openweathermaps.org', route),
+    collectProvider(weatherApiResult, v => weatherApiDto.currentWeather(v, metric), 'weatherapi.com', route),
+    collectProvider(smhiResult, v => smhiDto.currentWeather(v, metric), 'smhi.se', route),
+    collectProvider(metResult, v => metDto.currentWeather(v, metric), 'met.no', route),
+  ];
+  const sources = collected.filter(r => r.source).map(r => r.source);
+  const providers = collected.filter(r => r.provider).map(r => r.provider);
+  const errors = collected.filter(r => r.error).map(r => r.error);
 
   const averaged = mergeAndAverage(sources);
-
-  if (!averaged) {
-    return { error: "All weather providers failed", errors };
-  }
-
-  return {
-    ...averaged,
-    providers,
-    errors: errors.length > 0 ? errors : undefined,
-  };
+  if (!averaged) return { error: "All weather providers failed", errors };
+  return { ...averaged, providers, errors: errors.length > 0 ? errors : undefined };
 };
 
 /**
@@ -512,10 +474,6 @@ const processCurrentWeather = (owmResult, weatherApiResult, smhiResult, metResul
 const DATE_KEY_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 
 const processForecastWeather = (owmResult, weatherApiResult, smhiResult, metResult, metric = true, explicitTimezone = null, days = null) => {
-  const sources = [];
-  const errors = [];
-  const providers = [];
-
   // Compute timezone once — used for SMHI/MET DTO calls and for the date→weekday conversion below.
   // Prefer an explicitly supplied timezone (derived from current-weather results, which are more
   // reliable than forecast responses) so that SMHI/MET DTOs are not re-bucketed to UTC when a
@@ -524,53 +482,16 @@ const processForecastWeather = (owmResult, weatherApiResult, smhiResult, metResu
     ?? weatherApiResult.value?.location?.tz_id
     ?? (owmResult.value?.city?.timezone != null ? owmResult.value.city.timezone / 3600 : 'UTC');
 
-  if (owmResult.status === "fulfilled") {
-    const normalizedOwm = openWeatherMapsDto.forecastWeather(owmResult.value);
-    if (normalizedOwm) {
-      sources.push(normalizedOwm);
-      providers.push(normalizedOwm.provider || "openweathermaps.org");
-    }
-  } else {
-    const owmMsg = owmResult?.reason?.message ?? String(owmResult?.reason) ?? "Unknown error";
-    errors.push({ provider: "openweathermaps.org", message: owmMsg });
-    logError(owmResult.reason, { route: "weatherAggregator.forecastWeather" });
-  }
-
-  if (weatherApiResult.status === "fulfilled") {
-    const normalizedWeatherApi = weatherApiDto.forecastWeather(weatherApiResult.value, metric);
-    if (normalizedWeatherApi) {
-      sources.push(normalizedWeatherApi);
-      providers.push(normalizedWeatherApi.provider || "weatherapi.com");
-    }
-  } else {
-    const waMsg = weatherApiResult?.reason?.message ?? String(weatherApiResult?.reason) ?? "Unknown error";
-    errors.push({ provider: "weatherapi.com", message: waMsg });
-    logError(weatherApiResult.reason, { route: "weatherAggregator.forecastWeather" });
-  }
-
-  if (smhiResult.status === "fulfilled") {
-    const normalizedSmhi = smhiDto.forecastWeather(smhiResult.value, metric, timezone);
-    if (normalizedSmhi) {
-      sources.push(normalizedSmhi);
-      providers.push(normalizedSmhi.provider || "smhi.se");
-    }
-  } else {
-    const smhiMsg = smhiResult?.reason?.message ?? String(smhiResult?.reason) ?? "Unknown error";
-    errors.push({ provider: "smhi.se", message: smhiMsg });
-    logError(smhiResult.reason, { route: "weatherAggregator.forecastWeather" });
-  }
-
-  if (metResult.status === "fulfilled") {
-    const normalizedMet = metDto.forecastWeather(metResult.value, metric, timezone);
-    if (normalizedMet) {
-      sources.push(normalizedMet);
-      providers.push(normalizedMet.provider || "met.no");
-    }
-  } else {
-    const metMsg = metResult?.reason?.message ?? String(metResult?.reason) ?? "Unknown error";
-    errors.push({ provider: "met.no", message: metMsg });
-    logError(metResult.reason, { route: "weatherAggregator.forecastWeather" });
-  }
+  const route = 'weatherAggregator.forecastWeather';
+  const collected = [
+    collectProvider(owmResult, v => openWeatherMapsDto.forecastWeather(v), 'openweathermaps.org', route),
+    collectProvider(weatherApiResult, v => weatherApiDto.forecastWeather(v, metric), 'weatherapi.com', route),
+    collectProvider(smhiResult, v => smhiDto.forecastWeather(v, metric, timezone), 'smhi.se', route),
+    collectProvider(metResult, v => metDto.forecastWeather(v, metric, timezone), 'met.no', route),
+  ];
+  const sources = collected.filter(r => r.source).map(r => r.source);
+  const providers = collected.filter(r => r.provider).map(r => r.provider);
+  const errors = collected.filter(r => r.error).map(r => r.error);
 
   const merged = mergeForecastData(sources);
 

--- a/src/tests/api.test.mjs
+++ b/src/tests/api.test.mjs
@@ -56,6 +56,7 @@ jest.unstable_mockModule("../services/met.service.mjs", () => ({
 
 import request from "supertest";
 import { exampleIp, exampleLatLon, exampleLat } from "../utils/constants.mjs";
+import { clearRedisTestData } from "../services/redis.service.mjs";
 
 // Dynamically import app/start/stop after the mock is set up
 let app;
@@ -85,7 +86,8 @@ describe("API Routes", () => {
     }
   });
 
-  beforeEach(() => {
+  beforeEach(async () => {
+    await clearRedisTestData();
     owmMocks.currentWeather.mockResolvedValue(weather.data);
     owmMocks.forecastWeather.mockResolvedValue(weatherForecast.data);
     owmMocks.currentPollution.mockResolvedValue(airPollution.data);

--- a/src/tests/api.test.mjs
+++ b/src/tests/api.test.mjs
@@ -9,6 +9,8 @@ import {
   weather as weatherApiWeather,
   weatherForecast as weatherApiWeatherForecast,
 } from "../fixtures/weatherApi.fixture.mjs";
+import { smhiForecast } from "../fixtures/smhi.fixture.mjs";
+import { metForecast } from "../fixtures/met.fixture.mjs";
 
 // Stable mock function references so individual tests can override behaviour
 const owmMocks = {
@@ -24,6 +26,16 @@ const weatherApiMocks = {
   weatherWarnings: jest.fn().mockResolvedValue({ alerts: { alert: [] } }),
 };
 
+const smhiMocks = {
+  forecastWeather: jest.fn().mockResolvedValue(smhiForecast.data),
+  weatherWarnings: jest.fn().mockResolvedValue(null),
+};
+
+const metMocks = {
+  forecastWeather: jest.fn().mockResolvedValue(metForecast.data),
+  weatherWarnings: jest.fn().mockResolvedValue(null),
+};
+
 // Mock the OpenWeatherMaps service
 jest.unstable_mockModule("../services/openWeatherMaps.service.mjs", () => ({
   default: owmMocks,
@@ -32,6 +44,14 @@ jest.unstable_mockModule("../services/openWeatherMaps.service.mjs", () => ({
 // Mock the weatherApi service
 jest.unstable_mockModule("../services/weatherApi.service.mjs", () => ({
   default: weatherApiMocks,
+}));
+
+jest.unstable_mockModule("../services/smhi.service.mjs", () => ({
+  default: smhiMocks,
+}));
+
+jest.unstable_mockModule("../services/met.service.mjs", () => ({
+  default: metMocks,
 }));
 
 import request from "supertest";
@@ -73,6 +93,10 @@ describe("API Routes", () => {
     weatherApiMocks.currentWeather.mockResolvedValue(weatherApiWeather.data);
     weatherApiMocks.forecastWeather.mockResolvedValue(weatherApiWeatherForecast.data);
     weatherApiMocks.weatherWarnings.mockResolvedValue({ alerts: { alert: [] } });
+    smhiMocks.forecastWeather.mockResolvedValue(smhiForecast.data);
+    smhiMocks.weatherWarnings.mockResolvedValue(null);
+    metMocks.forecastWeather.mockResolvedValue(metForecast.data);
+    metMocks.weatherWarnings.mockResolvedValue(null);
   });
 
   afterAll(async () => {
@@ -140,14 +164,24 @@ describe("API Routes", () => {
       expect(res.body.data).toHaveProperty('forecastWeather');
     });
 
-    it('should still return 200 when the WeatherAPI provider fails', async () => {
+    it('should still return 200 with valid weather data when WeatherAPI is down', async () => {
       weatherApiMocks.currentWeather.mockRejectedValueOnce(new Error('WeatherAPI unavailable'));
       weatherApiMocks.forecastWeather.mockRejectedValueOnce(new Error('WeatherAPI unavailable'));
       const res = await request(app).get('/v1/weather').query(exampleLatLon);
       expect(res.status).toBe(200);
-      expect(res.body).toHaveProperty('data');
-      expect(res.body.data).toHaveProperty('currentWeather');
-      expect(res.body.data).toHaveProperty('forecastWeather');
+      // currentWeather still has real data from the remaining providers
+      expect(res.body.data.currentWeather).toHaveProperty('temperature');
+      expect(res.body.data.currentWeather.temperature).toHaveProperty('temp');
+      // weatherapi.com must be absent from providers since it failed
+      expect(res.body.data.currentWeather.providers).not.toContain('weatherapi.com');
+      // failure is reported in the errors array
+      expect(res.body.data.currentWeather.errors).toHaveLength(1);
+      expect(res.body.data.currentWeather.errors[0].provider).toBe('weatherapi.com');
+      // forecastWeather list is still populated
+      expect(res.body.data.forecastWeather).toHaveProperty('list');
+      expect(res.body.data.forecastWeather.providers).not.toContain('weatherapi.com');
+      expect(res.body.data.forecastWeather.errors).toHaveLength(1);
+      expect(res.body.data.forecastWeather.errors[0].provider).toBe('weatherapi.com');
     });
   });
 });


### PR DESCRIPTION
## Summary
- **Perf:** `moveRequestLogsToProcessing` now uses a single Redis MULTI/EXEC transaction instead of N serial `RPOPLPUSH` round-trips (up to 40 → 1)
- **Structure:** `collectProvider` in `weatherAggregator.service.mjs` refactored to return a value instead of mutating shared arrays, eliminating the 7-argument signature
- **Structure:** Removed try/catch from `requestLogs` and `errorLogs` controllers — Express 5 auto-catches async rejections and routes to the global `handleError` middleware, fixing the inconsistent error response shape and ensuring failures are written to `error_logs`
- **Tests:** SMHI and MET services are now mocked with fixtures in `api.test.mjs`, making the suite fully deterministic (no more real HTTP calls to external APIs)
- **Tests:** WeatherAPI outage test strengthened to assert the `errors` array is populated and `providers` correctly excludes the failed provider for both `currentWeather` and `forecastWeather`

## Test plan
- [ ] Full test suite passes in CI (Postgres + Redis required for integration tests)
- [ ] `weatherAggregator.service.test.mjs` — all aggregator unit tests pass
- [ ] `api.test.mjs` — WeatherAPI outage test passes with new assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved weather handling when providers fail by returning clear provider-specific error details while still returning usable results when possible.
  * Standardized the “all providers failed” response for both current and forecast weather, including consistent error information.

* **Performance / Reliability**
  * Streamlined request-log and error-log listing with efficient pagination and optional filtering.

* **Tests**
  * Expanded API test coverage using provider fixtures, including verification of provider exclusion and error reporting behavior when WeatherAPI fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->