### PR TITLE
update node-cron and resend dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,11 +17,11 @@
         "express-validator": "^7.3.0",
         "helmet": "^8.1.0",
         "jsonwebtoken": "^9.0.3",
-        "node-cron": "^4.2.1",
+        "node-cron": "^4.3.0",
         "pg": "^8.17.0",
         "rate-limit-redis": "^5.0.0",
         "redis": "^5.12.1",
-        "resend": "^6.11.0",
+        "resend": "^6.13.0",
         "sequelize": "^6.37.0",
         "umzug": "^3.8.2"
       },
@@ -6076,12 +6076,12 @@
       }
     },
     "node_modules/node-cron": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.2.1.tgz",
-      "integrity": "sha512-lgimEHPE/QDgFlywTd8yTR61ptugX3Qer29efeyWw2rv259HtGBNn1vZVmp8lB9uo9wC0t/AT4iGqXxia+CJFg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.3.0.tgz",
+      "integrity": "sha512-NeTIPjUfndOkKQnWCBJIfx44BZX7GiXe7KJq7Y2bwc96v/4+CMwuzwOLkAk+4nu6eSNcatoLFCDXcn4QNph/Rw==",
       "license": "ISC",
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=20"
       }
     },
     "node_modules/node-int64": {
@@ -6875,9 +6875,9 @@
       }
     },
     "node_modules/resend": {
-      "version": "6.12.4",
-      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.4.tgz",
-      "integrity": "sha512-lRpJ2Hxd+ht+JPDm97juRcUp9HOMuZyxaRFRFmc9Tx8iNWiei94Dx9v6SWufgKk2667C/uCeKKspMotOHSpCSg==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.13.0.tgz",
+      "integrity": "sha512-HjGT3/mOQev6enBIIl7LTUPqf5n8dg++6M78HUS27LjNyl/JvTuLW4jTNN+yvne8V5sWGDIwd0cdcNTslfcAOw==",
       "license": "MIT",
       "dependencies": {
         "postal-mime": "2.7.4",

--- a/package.json
+++ b/package.json
@@ -37,11 +37,11 @@
     "express-validator": "^7.3.0",
     "helmet": "^8.1.0",
     "jsonwebtoken": "^9.0.3",
-    "node-cron": "^4.2.1",
+    "node-cron": "^4.3.0",
     "pg": "^8.17.0",
     "rate-limit-redis": "^5.0.0",
     "redis": "^5.12.1",
-    "resend": "^6.11.0",
+    "resend": "^6.13.0",
     "sequelize": "^6.37.0",
     "umzug": "^3.8.2"
   },


### PR DESCRIPTION
## Summary
- `node-cron` 4.2.1 → 4.3.0
- `resend` 6.12.4 → 6.13.0
- Skipped `redis` 5→6 (major version, breaking changes)

## Test plan
- [x] Full test suite passes locally (99 tests)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)