### PR TITLE
add PM2 cluster mode to utilize both CPU cores

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,9 @@ COPY package*.json ./
 # Install production dependencies only
 RUN npm install --omit=dev
 
+# Install PM2 globally
+RUN npm install -g pm2
+
 # Install postgres client for pg_isready used in startup script
 RUN apk add --no-cache postgresql-client
 

--- a/ecosystem.config.cjs
+++ b/ecosystem.config.cjs
@@ -1,0 +1,8 @@
+module.exports = {
+  apps: [{
+    name: 'express-api',
+    script: './src/index.mjs',
+    instances: 2,
+    exec_mode: 'cluster',
+  }],
+};

--- a/src/cron.mjs
+++ b/src/cron.mjs
@@ -14,20 +14,26 @@ export const registerCronJobs = () => {
     }
   }, { timezone: 'UTC' });
 
+  // Only register on the primary worker to avoid duplicate deletes across cluster workers.
+  // NODE_APP_INSTANCE is set by PM2 cluster mode; absence means single-process (dev/test).
+  const isPrimaryWorker = !process.env.NODE_APP_INSTANCE || process.env.NODE_APP_INSTANCE === '0';
+
   // Daily at 05:00 UTC — delete logs older than 6 months
-  const purgeTask = cron.schedule('0 5 * * *', async () => {
-    try {
-      await purgeOldLogs();
-    } catch (err) {
-      devError('Scheduled log purge failed:', err);
-      await logError(err, { route: 'cron:purge-old-logs' });
-    }
-  }, { timezone: 'UTC' });
+  const purgeTask = isPrimaryWorker
+    ? cron.schedule('0 5 * * *', async () => {
+        try {
+          await purgeOldLogs();
+        } catch (err) {
+          devError('Scheduled log purge failed:', err);
+          await logError(err, { route: 'cron:purge-old-logs' });
+        }
+      }, { timezone: 'UTC' })
+    : null;
 
   return {
     stop: () => {
       flushTask.stop();
-      purgeTask.stop();
+      purgeTask?.stop();
     },
   };
 };

--- a/startup.sh
+++ b/startup.sh
@@ -20,4 +20,4 @@ done
 
 echo "Postgres is available, running migrations and starting app"
 npm run migrate
-exec npm start
+exec pm2-runtime ecosystem.config.cjs


### PR DESCRIPTION
## Summary
- Adds `ecosystem.config.cjs` to run 2 cluster workers via PM2 (matching the 2 vCPU server)
- Updates `Dockerfile` to install PM2 globally and `startup.sh` to use `pm2-runtime` (keeps process in foreground for correct Docker signal handling)
- Gates the purge cron job to the primary worker (`NODE_APP_INSTANCE === '0'`) to prevent duplicate deletes across workers — the flush job is already protected by a Redis distributed lock

## Test plan
- [ ] Build the Docker image and confirm container starts with 2 PM2 workers (`pm2 list` inside container)
- [ ] Confirm `docker stop` shuts down cleanly (no hanging processes)
- [ ] Confirm rate limiting still works correctly across workers (Redis-backed)
- [ ] Confirm auth flow (login + verify) works correctly across workers
- [ ] At 05:00 UTC, confirm purge job runs exactly once (check logs from only worker 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Application now runs with multi-instance clustering for improved reliability and performance.

* **Bug Fixes**
  * Prevented duplicate cron job execution across clustered application instances.

* **Chores**
  * Updated application startup process to use PM2 process manager for better stability and resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->